### PR TITLE
Add HTTP response caching with file-based storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ tokio = {version = "1.46.1", features = ["full"]}
 rustls = {  version= "0.23.31", features = ["aws-lc-rs"]}
 rustls-pemfile = "2.2.0"
 tokio-rustls = "0.26.2"
+fs2 = "0.4"

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -26,7 +26,10 @@ pub struct Conf {
     pub logs_min_level: String,
     pub logs_dir: Option<PathBuf>,
     pub load_balancing_enabled: bool,
-    pub load_balancing_servers: Vec<SocketAddr>
+    pub load_balancing_servers: Vec<SocketAddr>,
+    pub cache_enabled: bool,
+    pub cache_dir: Option<PathBuf>,
+    pub cache_patterns: Vec<String>
 }
 
 impl Conf {

--- a/src/conf/conf_builder.rs
+++ b/src/conf/conf_builder.rs
@@ -34,7 +34,10 @@ impl ConfBuilder {
             logs_min_level: "info".to_string(),
             logs_dir: None,
             load_balancing_enabled: false,
-            load_balancing_servers: Vec::new()
+            load_balancing_servers: Vec::new(),
+            cache_enabled: false,
+            cache_dir: None,
+            cache_patterns: Vec::new(),
         };
 
         Self::parse_args(&mut conf, args)?;
@@ -178,6 +181,21 @@ impl ConfBuilder {
             }
             if key == "php.socket" {
                 conf.php_socket = Some(value.to_string());
+            }
+
+            if key == "cache.enabled" {
+                conf.cache_enabled = enabled_values.contains(&value.to_lowercase().as_str());
+            }
+            if key == "cache.dir" {
+                let path = Path::new(value);
+                if path.exists() && path.is_dir() {
+                    conf.cache_dir = Some(path.into());
+                } else {
+                    return Err(format!("Invalid cache dir. Line no. {}", line_no))?;
+                }
+            }
+            if key == "cache.pattern" {
+                conf.cache_patterns.push(value.to_string());
             }
 
             line_no += 1;

--- a/src/server/cache.rs
+++ b/src/server/cache.rs
@@ -1,18 +1,146 @@
-pub struct Cache {
-    
-}
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+use tokio::io::AsyncWriteExt;
+use crate::server::http_stream::HttpStream;
+
+use crate::conf::Conf;
+
+pub struct Cache;
+
 pub struct CacheStatistic {
     pub size: i32,
 }
 
 impl CacheStatistic {
     pub fn new() -> CacheStatistic {
-        CacheStatistic {
-            size: 0,
+        CacheStatistic { size: 0 }
+    }
+
+    pub fn recalculate_files() -> Vec<String> {
+        vec![]
+    }
+}
+
+impl Cache {
+    pub fn qualifies(path: &str, conf: &Conf) -> bool {
+        if !conf.cache_enabled {
+            return false;
+        }
+        conf.cache_patterns.iter().any(|p| path.starts_with(p))
+    }
+
+    pub fn key_to_filename(key: &str) -> String {
+        key.trim_start_matches('/')
+            .replace('/', "-")
+    }
+
+    pub fn file_path(conf: &Conf, key: &str) -> Option<PathBuf> {
+        conf.cache_dir.as_ref().map(|dir| dir.join(Self::key_to_filename(key)))
+    }
+
+    pub fn delete_like(conf: &Conf, like: &str) {
+        if !conf.cache_enabled {
+            return;
+        }
+        if let Some(dir) = &conf.cache_dir {
+            let prefix = Self::key_to_filename(like);
+            if let Ok(entries) = fs::read_dir(dir) {
+                for entry in entries.flatten() {
+                    if let Ok(name) = entry.file_name().into_string() {
+                        if name.starts_with(&prefix) {
+                            let _ = fs::remove_file(entry.path());
+                        }
+                    }
+                }
+            }
         }
     }
-    
-    pub fn recalculate_files() -> Vec<String>{
-        vec![]
+
+    pub fn process_headers(
+        headers: &mut Vec<(String, String)>,
+        query_path: &str,
+        conf: &Conf,
+    ) -> Option<PathBuf> {
+        let mut cache_enabled = false;
+        let mut delete_prefix: Option<String> = None;
+
+        headers.retain(|(k, v)| {
+            if k.eq_ignore_ascii_case("x-cache-path-query") {
+                cache_enabled = true;
+                false
+            } else if k.eq_ignore_ascii_case("x-cache-delete-like") {
+                delete_prefix = Some(v.clone());
+                false
+            } else {
+                true
+            }
+        });
+
+        if let Some(prefix) = delete_prefix {
+            Cache::delete_like(conf, prefix.as_str());
+        }
+
+        if cache_enabled {
+            if let Some(path) = Cache::file_path(conf, query_path) {
+                if let Some(parent) = path.parent() {
+                    let _ = fs::create_dir_all(parent);
+                }
+                return Some(path);
+            }
+        }
+        None
+    }
+
+    pub fn write(buf: &[u8], path: &Path) -> io::Result<()> {
+        let lock_path = path.with_extension("lock");
+        let tmp_path = path.with_extension("tmp");
+
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&lock_path)?;
+        lock_file.lock_exclusive()?;
+
+        {
+            let mut tmp = File::create(&tmp_path)?;
+            tmp.write_all(buf)?;
+        }
+        fs::rename(&tmp_path, path)?;
+
+        let _ = lock_file.unlock();
+        let _ = fs::remove_file(lock_path);
+        Ok(())
+    }
+
+    pub async fn send_cached(stream: &mut HttpStream, path: &Path) -> io::Result<()> {
+        let mut file = File::open(path)?;
+        let mut buff = [0; 256 * 1024];
+        loop {
+            let read = file.read(&mut buff)?;
+            if read == 0 { break; }
+            stream.write(&buff[..read]).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn try_serve_cached(
+        stream: &mut HttpStream,
+        path: &str,
+        key: &str,
+        conf: &Conf,
+    ) -> io::Result<bool> {
+        if Cache::qualifies(path, conf) {
+            if let Some(file_path) = Cache::file_path(conf, key) {
+                if file_path.is_file() {
+                    Cache::send_cached(stream, &file_path).await?;
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
     }
 }

--- a/src/server/http_server.rs
+++ b/src/server/http_server.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -9,7 +9,7 @@ use tokio_rustls::server::TlsStream;
 use tokio_rustls::TlsAcceptor;
 
 use uuid::Uuid;
-use crate::server::cache::CacheStatistic;
+use crate::server::cache::{CacheStatistic, Cache};
 use crate::conf::Conf;
 use request::Request;
 use crate::logger::Logger;
@@ -161,7 +161,7 @@ async fn accept_request(addr: SocketAddr,
 
     if conf.load_balancing_enabled {
         let dispatcher = Arc::new(Mutex::new(Dispatcher::new(&conf)));
-        match dispatch_request(http_stream, dispatcher).await {
+        match dispatch_request(http_stream, dispatcher, conf).await {
             Ok(_) => server_logger.log_d("Request passed upstream successfully!"),
             Err(e) => server_logger.log_e(format!("Could not transfer stream. {}", e).as_str()),
         }
@@ -185,6 +185,11 @@ async fn handle_request(
     let id = Uuid::new_v4();
     logger.log_i(format!("{}| Request {} {}", id, request.method(), request.query_path()).as_str());
 
+    if Cache::try_serve_cached(request.stream_mut(), request.path(), request.query_path(), conf).await? {
+        logger.log_i(format!("{}| Request succeed", id).as_str());
+        return Ok(());
+    }
+
     let response = match create_response(&mut request, conf).await {
         Ok(response) => response,
         Err(e) => {
@@ -193,7 +198,7 @@ async fn handle_request(
         }
     };
 
-    if let Err(e) = request.output_response(response).await {
+    if let Err(e) = request.output_response(response, conf).await {
         logger.log_e(format!("{}| Request failed| {}", id, e).as_str());
         return Err(e);
     }
@@ -234,35 +239,87 @@ async fn get_file_path_response(request: &mut Request, conf: &Conf) -> Result<Re
 }
 
 async fn dispatch_request(mut downstream: HttpStream,
-                          dispatcher: Arc<Mutex<Dispatcher>>) -> Result<(), Box<dyn Error>> {
+                          dispatcher: Arc<Mutex<Dispatcher>>,
+                          conf: &Conf) -> Result<(), Box<dyn Error>> {
+    if Cache::try_serve_cached(&mut downstream, downstream.path(), downstream.query_path(), conf).await? {
+        return Ok(());
+    }
+
     let endpoint = match dispatcher.lock().unwrap().get() {
         Some(e) => e,
-        None => return Err("No endpoint to handle request")?
+        None => return Err("No endpoint to handle request")?,
     };
 
     let mut upstream = match TcpStream::connect(endpoint).await {
         Ok(stream) => stream,
-        Err(_) => Err("Could not connect with upstream")?
+        Err(_) => Err("Could not connect with upstream")?,
     };
     loop {
         let mut buff = [0; 4 * 1024];
         let read_size = downstream.read(&mut buff).await?;
-        if read_size == 0 {
-            break;
-        }
-        upstream.write_all(&buff[0..read_size]).await?;
-        break;
+        if read_size == 0 { break; }
+        upstream.write_all(&buff[..read_size]).await?;
     }
+
+    let mut resp_buf: Vec<u8> = Vec::new();
+    let mut headers_parsed = false;
+    let mut cache_path: Option<PathBuf> = None;
 
     loop {
         let mut buff = [0; 4 * 1024];
         let read_size = upstream.read(&mut buff).await?;
-        if read_size == 0 {
-            break;
+        if read_size == 0 { break; }
+
+        if !headers_parsed {
+            resp_buf.extend_from_slice(&buff[..read_size]);
+            if let Some(pos) = resp_buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                let header_end = pos + 4;
+                let (header_bytes, body_bytes) = resp_buf.split_at(header_end);
+                let header_str = String::from_utf8_lossy(header_bytes);
+                let mut lines = header_str.split("\r\n");
+                let status_line_raw = lines.next().unwrap_or("");
+                let mut headers: Vec<(String, String)> = lines
+                    .filter(|l| !l.is_empty())
+                    .filter_map(|line| {
+                        line.find(':').map(|idx| (
+                            line[..idx].to_string(),
+                            line[idx + 1..].to_string(),
+                        ))
+                    })
+                    .collect();
+                cache_path = Cache::process_headers(&mut headers, downstream.query_path(), conf);
+
+                let mut head = format!("{}\r\n", status_line_raw).into_bytes();
+                for (k, v) in headers.iter() {
+                    head.extend_from_slice(format!("{}:{}\r\n", k, v).as_bytes());
+                }
+                head.extend_from_slice(b"\r\n");
+
+                downstream.write_all(&head).await?;
+                if !body_bytes.is_empty() {
+                    downstream.write_all(body_bytes).await?;
+                }
+
+                if cache_path.is_some() {
+                    let mut new_buf = head;
+                    new_buf.extend_from_slice(body_bytes);
+                    resp_buf = new_buf;
+                } else {
+                    resp_buf.clear();
+                }
+                headers_parsed = true;
+            }
+        } else {
+            downstream.write_all(&buff[..read_size]).await?;
+            if cache_path.is_some() {
+                resp_buf.extend_from_slice(&buff[..read_size]);
+            }
         }
-        downstream.write(&buff[0..read_size]).await?;
+    }
+
+    if let Some(path) = cache_path {
+        let _ = Cache::write(&resp_buf, &path);
     }
 
     Ok(())
 }
-

--- a/src/server/http_server/request.rs
+++ b/src/server/http_server/request.rs
@@ -2,10 +2,13 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::fs;
+use std::io::Read;
 use urlencoding::decode;
 use crate::conf::Conf;
 use crate::server::http_stream::HttpStream;
 use crate::server::http_server::response::Response;
+use crate::server::cache::Cache;
 
 pub struct Request {
     stream:  HttpStream,
@@ -54,33 +57,68 @@ impl Request {
         self.file_path = file_path;
     }
 
+    pub fn stream_mut(&mut self) -> &mut HttpStream { &mut self.stream }
+
     pub async fn read_body(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.stream.read(buf).await
     }
 
-    pub async fn output_response(mut self, mut res: Response) -> Result<(), Box<dyn Error>> {
-        self.stream.write(res.status_line().as_bytes()).await?;
+    pub async fn output_response(
+        mut self,
+        mut res: Response,
+        conf: &Conf,
+    ) -> Result<(), Box<dyn Error>> {
+        let mut headers: Vec<(String, String)> = res
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        let cache_path = Cache::process_headers(&mut headers, self.query_path(), conf);
 
-        let mut idx = 0;
-        for (key, value) in res.headers() {
-            if idx == res.headers().len() - 1 {
-                self.stream.write(format!("{}:{}", key, value).as_bytes()).await?;
+        let status_line = res.status_line();
+        self.stream.write(status_line.as_bytes()).await?;
+        let mut cache_buf: Option<Vec<u8>> = if cache_path.is_some() {
+            let mut v = Vec::new();
+            v.extend_from_slice(status_line.as_bytes());
+            Some(v)
+        } else {
+            None
+        };
+
+        let headers_len = headers.len();
+        for (idx, (key, value)) in headers.iter().enumerate() {
+            let line = if idx == headers_len - 1 {
+                format!("{}:{}", key, value)
+            } else {
+                format!("{}:{}\n", key, value)
+            };
+            self.stream.write(line.as_bytes()).await?;
+            if let Some(buf) = cache_buf.as_mut() {
+                buf.extend_from_slice(line.as_bytes());
             }
-            else {
-                self.stream.write(format!("{}:{}\n", key, value).as_bytes()).await?;
-            }
-            idx += 1;
         }
 
         self.stream.write("\r\n\r\n".as_bytes()).await?;
+        if let Some(buf) = cache_buf.as_mut() {
+            buf.extend_from_slice("\r\n\r\n".as_bytes());
+        }
 
         loop {
             let mut buff = [0; 256 * 1024];
             let read_size = res.read(&mut buff)?;
             if read_size == 0 {
-                return Ok(());
+                break;
             }
             self.stream.write(&buff[0..read_size]).await?;
+            if let Some(buf) = cache_buf.as_mut() {
+                buf.extend_from_slice(&buff[0..read_size]);
+            }
         }
+
+        if let (Some(buf), Some(final_path)) = (cache_buf, cache_path) {
+            let _ = Cache::write(&buf, &final_path);
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- add cache configuration settings
- support saving and deleting cached responses using response headers
- serve cached files for configured paths
- stream upstream responses in dispatch_request and stop buffering once caching is unnecessary
- buffer responses in memory before writing cache files
- guard cache file writes with exclusive locks and share caching logic with load balancer
- stream upstream responses directly to clients and only buffer when caching is requested

## Testing
- `cargo test` *(fails: failed to download from https://index.crates.io/config.json: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c6f6b89efc83308f6b3fc14ab8bb34